### PR TITLE
rank update

### DIFF
--- a/models/stitch/base/adwords_criteria_performance.sql
+++ b/models/stitch/base/adwords_criteria_performance.sql
@@ -2,7 +2,8 @@ with base as (
 
     select
         *,
-        rank() over (partition by day order by _sdc_report_datetime desc) as latest
+        rank() over (partition by day, customerid
+            order by _sdc_report_datetime desc) as latest
     from {{ var('criteria_performance_report') }}
 
 ),


### PR DESCRIPTION
* updating rank to include customerid if multiple adwords are pulled in to clients account
* if only one account pulled into package, this will not change anything
* if customer has multiple adwords accounts, this will ensure if an account sync before another, it won't exclude their data