### PR TITLE
Add ID to Adwords Ad Performance Prep

### DIFF
--- a/models/stitch/transform/adwords_ad_performance_prep.sql
+++ b/models/stitch/transform/adwords_ad_performance_prep.sql
@@ -1,5 +1,6 @@
 select
 
+    id,
     date_day,
     null::varchar as utm_medium,
     null::varchar as utm_source,


### PR DESCRIPTION
The `schema.yml` file tests for an ID, but the ID currently isn't being pulled in. 
This PR adds the id value. 