### PR TITLE
Fix: updated adwords ad performance adapter model

### DIFF
--- a/macros/stitch/stitch_adwords_criteria_performance.sql
+++ b/macros/stitch/stitch_adwords_criteria_performance.sql
@@ -17,13 +17,7 @@ aggregated as (
 
     select
 
-        {{ dbt_utils.surrogate_key (
-            'customerid',
-            'keywordid',
-            'adgroupid',
-            'day'
-            
-        ) }}::varchar as id,
+        md5(customerid::varchar || keywordid::varchar || adgroupid::varchar || day::varchar) as id,
         
         day::date as date_day,
         keywordid as criteria_id,

--- a/macros/stitch/stitch_adwords_criteria_performance.sql
+++ b/macros/stitch/stitch_adwords_criteria_performance.sql
@@ -16,8 +16,13 @@ with criteria_base as (
 aggregated as (
 
     select
-
-        md5(customerid::varchar || keywordid::varchar || adgroupid::varchar || day::varchar) as id,
+        
+        {{ dbt_utils.surrogate_key (
+            'customerid',
+            'keywordid',
+            'adgroupid',
+            'day'
+        ) }}::varchar as id,
         
         day::date as date_day,
         keywordid as criteria_id,

--- a/macros/stitch/stitch_adwords_criteria_performance.sql
+++ b/macros/stitch/stitch_adwords_criteria_performance.sql
@@ -33,7 +33,7 @@ aggregated as (
         sum(cast((cost::float/1000000::float) as numeric(38,6))) as spend
 
     from criteria_base
-    group by 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11
+    {{ dbt_utils.group_by(11) }}
 
 ), 
 

--- a/macros/stitch/stitch_adwords_criteria_performance.sql
+++ b/macros/stitch/stitch_adwords_criteria_performance.sql
@@ -17,7 +17,14 @@ aggregated as (
 
     select
 
-        md5(customerid::varchar || keywordid::varchar || adgroupid::varchar || day::varchar) as id,
+        {{ dbt_utils.surrogate_key (
+            'customerid',
+            'keywordid',
+            'adgroupid',
+            'day'
+            
+        ) }}::varchar as id,
+        
         day::date as date_day,
         keywordid as criteria_id,
         adgroup as ad_group_name,
@@ -40,9 +47,11 @@ aggregated as (
 ranked as (
 
     select
+    
         *,
         rank() over (partition by id
             order by _sdc_report_datetime desc) as latest
+            
     from aggregated
 
 ),

--- a/macros/stitch/stitch_adwords_url_performance.sql
+++ b/macros/stitch/stitch_adwords_url_performance.sql
@@ -22,13 +22,13 @@ aggregated as (
         day::date as date_day,
 
         split_part(finalurl, '?', 1) as base_url,
-        {{ dbt_utils.get_url_parameter('finalurl', 'host') }}::varchar as url_host,
-        '/' || {{ dbt_utils.get_url_parameter('finalurl', 'path') }}::varchar as url_path,
-        {{ dbt_utils.get_url_parameter('finalurl', 'utm_source') }} as utm_source,
-        {{ dbt_utils.get_url_parameter('finalurl', 'utm_medium') }} as utm_medium,
-        {{ dbt_utils.get_url_parameter('finalurl', 'utm_campaign') }} as utm_campaign,
-        {{ dbt_utils.get_url_parameter('finalurl', 'utm_content') }} as utm_content,
-        {{ dbt_utils.get_url_parameter('finalurl', 'utm_term') }} as utm_term,
+        ({{ get_url_parameter(field='finalurl', url_parameter='host') }})::varchar as url_host,
+        '/' || ({{ get_url_parameter(field='finalurl', url_parameter='path') }})::varchar as url_path,
+        nullif(({{ get_url_parameter(field='finalurl', url_parameter='utm_campaign') }})::varchar, '') as utm_campaign,
+        nullif(({{ get_url_parameter(field='finalurl', url_parameter='utm_source') }})::varchar, '') as utm_source,
+        nullif(({{ get_url_parameter(field='finalurl', url_parameter='utm_medium') }})::varchar, '') as utm_medium,
+        nullif(({{ get_url_parameter(field='finalurl', url_parameter='utm_content') }})::varchar, '') as utm_content,
+        nullif(({{ get_url_parameter(field='finalurl', url_parameter='utm_term') }})::varchar, '') as utm_term,
         campaignid as campaign_id,
         campaign as campaign_name,
         adgroupid as ad_group_id,
@@ -42,18 +42,16 @@ aggregated as (
 
     from base
 
-    {{ dbt_utils.group_by(16) }}
+    group by 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
 
 ),
 
 ranked as (
 
     select
-    
         *,
         rank() over (partition by id
             order by _sdc_report_datetime desc) as latest
-            
     from aggregated
 
 ),
@@ -83,14 +81,7 @@ aggregated as (
 
     select
 
-        {{ dbt_utils.surrogate_key (
-            'customerid',
-            'finalurl',
-            'day',
-            'campaignid',
-            'adgroupid'
-        
-        ) }}::varchar as id,
+        md5(customerid::varchar || coalesce(finalurl::varchar, '') || day::varchar || campaignid::varchar || adgroupid::varchar) as id,
 
         day::date as date_day,
 
@@ -116,18 +107,16 @@ aggregated as (
 
     from base
 
-    {{ dbt_utils.group_by(16) }}
+    group by 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
 
 ),
 
 ranked as (
 
     select
-    
         *,
         rank() over (partition by id
             order by _sdc_report_datetime desc) as latest
-            
     from aggregated
 
 ),

--- a/macros/stitch/stitch_adwords_url_performance.sql
+++ b/macros/stitch/stitch_adwords_url_performance.sql
@@ -30,7 +30,7 @@ aggregated as (
 
         split_part(finalurl, '?', 1) as base_url,
         {{ dbt_utils.get_url_host('finalurl') }} as url_host,
-        '/' {{ dbt_utils.get_url_path('finalurl') }} as url_path,
+        '/' || {{ dbt_utils.get_url_path('finalurl') }} as url_path,
         {{ dbt_utils.get_url_parameter('finalurl', 'utm_source') }} as utm_source,
         {{ dbt_utils.get_url_parameter('finalurl', 'utm_medium') }} as utm_medium,
         {{ dbt_utils.get_url_parameter('finalurl', 'utm_campaign') }} as utm_campaign,

--- a/macros/stitch/stitch_adwords_url_performance.sql
+++ b/macros/stitch/stitch_adwords_url_performance.sql
@@ -28,7 +28,7 @@ aggregated as (
 
         day::date as date_day,
 
-        split_part(finalurl, '?', 1) as base_url,
+        {{ dbt_utils.split_part('finalurl', "'?'", 1) }} as base_url,
         {{ dbt_utils.get_url_host('finalurl') }} as url_host,
         '/' || {{ dbt_utils.get_url_path('finalurl') }} as url_path,
         {{ dbt_utils.get_url_parameter('finalurl', 'utm_source') }} as utm_source,

--- a/macros/stitch/stitch_adwords_url_performance.sql
+++ b/macros/stitch/stitch_adwords_url_performance.sql
@@ -17,14 +17,7 @@ aggregated as (
 
     select
 
-        {{ dbt_utils.surrogate_key (
-            'customerid',
-            'finalurl',
-            'day',
-            'campaignid',
-            'adgroupid'
-        
-        ) }}::varchar as id,
+        md5(customerid::varchar || coalesce(finalurl::varchar, '') || day::varchar || campaignid::varchar || adgroupid::varchar) as id,
 
         day::date as date_day,
 

--- a/macros/stitch/stitch_adwords_url_performance.sql
+++ b/macros/stitch/stitch_adwords_url_performance.sql
@@ -17,92 +17,25 @@ aggregated as (
 
     select
 
-        md5(customerid::varchar || coalesce(finalurl::varchar, '') || day::varchar || campaignid::varchar || adgroupid::varchar) as id,
-
-        day::date as date_day,
-
-        split_part(finalurl, '?', 1) as base_url,
-        {{ dbt_utils.get_url_parameter('finalurl', 'host') }}::varchar as url_host,
-        '/' || {{ dbt_utils.get_url_parameter('finalurl', 'path') }}::varchar as url_path,
-        {{ dbt_utils.get_url_parameter('finalurl', 'utm_source') }} as utm_source,
-        {{ dbt_utils.get_url_parameter('finalurl', 'utm_medium') }} as utm_medium,
-        {{ dbt_utils.get_url_parameter('finalurl', 'utm_campaign') }} as utm_campaign,
-        {{ dbt_utils.get_url_parameter('finalurl', 'utm_content') }} as utm_content,
-        {{ dbt_utils.get_url_parameter('finalurl', 'utm_term') }} as utm_term,
-        campaignid as campaign_id,
-        campaign as campaign_name,
-        adgroupid as ad_group_id,
-        adgroup as ad_group_name,
-        customerid as customer_id,
-        _sdc_report_datetime,
-
-        sum(clicks) as clicks,
-        sum(impressions) as impressions,
-        sum(cast((cost::float/1000000::float) as numeric(38,6))) as spend
-
-    from base
-
-    {{ dbt_utils.group_by(16) }}
-
-),
-
-ranked as (
-
-    select
-    
-        *,
-        rank() over (partition by id
-            order by _sdc_report_datetime desc) as latest
-            
-    from aggregated
-
-),
-
-final as (
-
-    select *
-    from ranked
-    where latest = 1
-
-)
-
-select * from final
-
-{% endmacro %}
-
-
-{% macro snowflake__stitch_adwords_url_performance() %}
-
-with base as (
-
-    select * from {{ var('final_url_performance_report') }}
-
-),
-
-aggregated as (
-
-    select
-
         {{ dbt_utils.surrogate_key (
             'customerid',
             'finalurl',
             'day',
             'campaignid',
             'adgroupid'
-        
+            
         ) }}::varchar as id,
 
         day::date as date_day,
 
         split_part(finalurl, '?', 1) as base_url,
-        parse_url(finalurl)['host']::varchar as url_host,
-        '/' || parse_url(finalurl)['path']::varchar as url_path,
-        nullif(parse_url(finalurl)['parameters']['utm_campaign']::varchar, '') as utm_campaign,
-        nullif(parse_url(finalurl)['parameters']['utm_source']::varchar, '') as utm_source,
-        nullif(parse_url(finalurl)['parameters']['utm_medium']::varchar, '') as utm_medium,
-        nullif(parse_url(finalurl)['parameters']['utm_content']::varchar, '') as utm_content,
-        nullif(parse_url(finalurl)['parameters']['utm_term']::varchar, '') as utm_term,
-
+        {{ dbt_utils.get_url_host('finalurl') }} as url_host,
+        '/' {{ dbt_utils.get_url_path('finalurl') }} as url_path,
+        {{ dbt_utils.get_url_parameter('finalurl', 'utm_source') }} as utm_source,
+        {{ dbt_utils.get_url_parameter('finalurl', 'utm_medium') }} as utm_medium,
+        {{ dbt_utils.get_url_parameter('finalurl', 'utm_campaign') }} as utm_campaign,
+        {{ dbt_utils.get_url_parameter('finalurl', 'utm_content') }} as utm_content,
+        {{ dbt_utils.get_url_parameter('finalurl', 'utm_term') }} as utm_term,
         campaignid as campaign_id,
         campaign as campaign_name,
         adgroupid as ad_group_id,

--- a/macros/stitch/stitch_adwords_url_performance.sql
+++ b/macros/stitch/stitch_adwords_url_performance.sql
@@ -22,13 +22,13 @@ aggregated as (
         day::date as date_day,
 
         split_part(finalurl, '?', 1) as base_url,
-        ({{ get_url_parameter(field='finalurl', url_parameter='host') }})::varchar as url_host,
-        '/' || ({{ get_url_parameter(field='finalurl', url_parameter='path') }})::varchar as url_path,
-        nullif(({{ get_url_parameter(field='finalurl', url_parameter='utm_campaign') }})::varchar, '') as utm_campaign,
-        nullif(({{ get_url_parameter(field='finalurl', url_parameter='utm_source') }})::varchar, '') as utm_source,
-        nullif(({{ get_url_parameter(field='finalurl', url_parameter='utm_medium') }})::varchar, '') as utm_medium,
-        nullif(({{ get_url_parameter(field='finalurl', url_parameter='utm_content') }})::varchar, '') as utm_content,
-        nullif(({{ get_url_parameter(field='finalurl', url_parameter='utm_term') }})::varchar, '') as utm_term,
+        {{ dbt_utils.get_url_parameter('finalurl', 'host') }}::varchar as url_host,
+        '/' || {{ dbt_utils.get_url_parameter('finalurl', 'path') }}::varchar as url_path,
+        {{ dbt_utils.get_url_parameter('finalurl', 'utm_source') }} as utm_source,
+        {{ dbt_utils.get_url_parameter('finalurl', 'utm_medium') }} as utm_medium,
+        {{ dbt_utils.get_url_parameter('finalurl', 'utm_campaign') }} as utm_campaign,
+        {{ dbt_utils.get_url_parameter('finalurl', 'utm_content') }} as utm_content,
+        {{ dbt_utils.get_url_parameter('finalurl', 'utm_term') }} as utm_term,
         campaignid as campaign_id,
         campaign as campaign_name,
         adgroupid as ad_group_id,
@@ -42,7 +42,7 @@ aggregated as (
 
     from base
 
-    group by 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
+    {{ dbt_utils.group_by(16) }}
 
 ),
 
@@ -107,7 +107,7 @@ aggregated as (
 
     from base
 
-    group by 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
+    {{ dbt_utils.group_by(16) }}
 
 ),
 

--- a/macros/stitch/stitch_adwords_url_performance.sql
+++ b/macros/stitch/stitch_adwords_url_performance.sql
@@ -17,7 +17,14 @@ aggregated as (
 
     select
 
-        md5(customerid::varchar || coalesce(finalurl::varchar, '') || day::varchar || campaignid::varchar || adgroupid::varchar) as id,
+        {{ dbt_utils.surrogate_key (
+            'customerid',
+            'finalurl',
+            'day',
+            'campaignid',
+            'adgroupid'
+        
+        ) }}::varchar as id,
 
         day::date as date_day,
 
@@ -49,9 +56,11 @@ aggregated as (
 ranked as (
 
     select
+    
         *,
         rank() over (partition by id
             order by _sdc_report_datetime desc) as latest
+            
     from aggregated
 
 ),
@@ -81,7 +90,14 @@ aggregated as (
 
     select
 
-        md5(customerid::varchar || coalesce(finalurl::varchar, '') || day::varchar || campaignid::varchar || adgroupid::varchar) as id,
+        {{ dbt_utils.surrogate_key (
+            'customerid',
+            'finalurl',
+            'day',
+            'campaignid',
+            'adgroupid'
+        
+        ) }}::varchar as id,
 
         day::date as date_day,
 
@@ -114,9 +130,11 @@ aggregated as (
 ranked as (
 
     select
+    
         *,
         rank() over (partition by id
             order by _sdc_report_datetime desc) as latest
+            
     from aggregated
 
 ),

--- a/macros/stitch/stitch_adwords_url_performance.sql
+++ b/macros/stitch/stitch_adwords_url_performance.sql
@@ -22,13 +22,13 @@ aggregated as (
         day::date as date_day,
 
         split_part(finalurl, '?', 1) as base_url,
-        ({{ get_url_parameter(field='finalurl', url_parameter='host') }})::varchar as url_host,
-        '/' || ({{ get_url_parameter(field='finalurl', url_parameter='path') }})::varchar as url_path,
-        nullif(({{ get_url_parameter(field='finalurl', url_parameter='utm_campaign') }})::varchar, '') as utm_campaign,
-        nullif(({{ get_url_parameter(field='finalurl', url_parameter='utm_source') }})::varchar, '') as utm_source,
-        nullif(({{ get_url_parameter(field='finalurl', url_parameter='utm_medium') }})::varchar, '') as utm_medium,
-        nullif(({{ get_url_parameter(field='finalurl', url_parameter='utm_content') }})::varchar, '') as utm_content,
-        nullif(({{ get_url_parameter(field='finalurl', url_parameter='utm_term') }})::varchar, '') as utm_term,
+        {{ dbt_utils.get_url_parameter('finalurl', 'host') }}::varchar as url_host,
+        '/' || {{ dbt_utils.get_url_parameter('finalurl', 'path') }}::varchar as url_path,
+        {{ dbt_utils.get_url_parameter('finalurl', 'utm_source') }} as utm_source,
+        {{ dbt_utils.get_url_parameter('finalurl', 'utm_medium') }} as utm_medium,
+        {{ dbt_utils.get_url_parameter('finalurl', 'utm_campaign') }} as utm_campaign,
+        {{ dbt_utils.get_url_parameter('finalurl', 'utm_content') }} as utm_content,
+        {{ dbt_utils.get_url_parameter('finalurl', 'utm_term') }} as utm_term,
         campaignid as campaign_id,
         campaign as campaign_name,
         adgroupid as ad_group_id,
@@ -42,16 +42,18 @@ aggregated as (
 
     from base
 
-    group by 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
+    {{ dbt_utils.group_by(16) }}
 
 ),
 
 ranked as (
 
     select
+    
         *,
         rank() over (partition by id
             order by _sdc_report_datetime desc) as latest
+            
     from aggregated
 
 ),
@@ -81,7 +83,14 @@ aggregated as (
 
     select
 
-        md5(customerid::varchar || coalesce(finalurl::varchar, '') || day::varchar || campaignid::varchar || adgroupid::varchar) as id,
+        {{ dbt_utils.surrogate_key (
+            'customerid',
+            'finalurl',
+            'day',
+            'campaignid',
+            'adgroupid'
+        
+        ) }}::varchar as id,
 
         day::date as date_day,
 
@@ -107,16 +116,18 @@ aggregated as (
 
     from base
 
-    group by 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16
+    {{ dbt_utils.group_by(16) }}
 
 ),
 
 ranked as (
 
     select
+    
         *,
         rank() over (partition by id
             order by _sdc_report_datetime desc) as latest
+            
     from aggregated
 
 ),

--- a/macros/utils/get_url_parameter.sql
+++ b/macros/utils/get_url_parameter.sql
@@ -1,9 +1,0 @@
-{% macro get_url_parameter(field, url_parameter) -%}
-
-{%- set formatted_url_parameter = "'" + url_parameter + "='" -%}
-
-{%- set split = dbt_utils.split_part(dbt_utils.split_part(field, formatted_url_parameter, 2), "'&'", 1) -%}
-
-nullif({{ split }},'')
-
-{%- endmacro %}

--- a/models/stitch/adapters/adwords_ad_performance_adapter.sql
+++ b/models/stitch/adapters/adwords_ad_performance_adapter.sql
@@ -1,7 +1,13 @@
 select
 
     date_day as campaign_date,
-    criteria_id,
+    url_host,
+    url_path,
+    utm_source,
+    utm_medium,
+    utm_campaign,
+    utm_content,
+    utm_term,
     ad_group_id,
     ad_group_name,
     campaign_id,
@@ -11,4 +17,4 @@ select
     impressions,
     'adwords' as platform
 
-from {{ref('adwords_criteria_performance')}}
+from {{ref('adwords_url_performance')}}

--- a/models/stitch/adapters/adwords_ad_performance_adapter.sql
+++ b/models/stitch/adapters/adwords_ad_performance_adapter.sql
@@ -1,20 +1,40 @@
-select
+with criteria_performance as (
+    
+    select * from {{ ref('adwords_criteria_performance') }}
+    
+),
 
-    date_day as campaign_date,
-    url_host,
-    url_path,
-    utm_source,
-    utm_medium,
-    utm_campaign,
-    utm_content,
-    utm_term,
-    ad_group_id,
-    ad_group_name,
-    campaign_id,
-    campaign_name,
-    clicks,
-    spend,
-    impressions,
-    'adwords' as platform
+url_performance as (
+    
+    select * from {{ ref('adwords_url_performance') }}
+    
+),
 
-from {{ref('adwords_url_performance')}}
+joined as (
+
+    select
+
+        criteria_performance.date_day as campaign_date,
+        url_performance.url_host,
+        url_performance.url_path,
+        url_performance.utm_source,
+        url_performance.utm_medium,
+        url_performance.utm_campaign,
+        url_performance.utm_content,
+        url_performance.utm_term,
+        criteria_performance.ad_group_id,
+        criteria_performance.ad_group_name,
+        criteria_performance.campaign_id,
+        criteria_performance.campaign_name,
+        criteria_performance.criteria_id,
+        criteria_performance.clicks,
+        criteria_performance.spend,
+        criteria_performance.impressions,
+        'adwords' as platform
+
+    from criteria_performance
+    left join url_performance using (campaign_id)
+    
+)
+
+select * from joined

--- a/models/stitch/base/schema.yml
+++ b/models/stitch/base/schema.yml
@@ -1,48 +1,51 @@
-adwords_click_performance:
-    constraints:
-        unique:
-            - gclid
-        not_null:
-            - gclid
+version: 2
 
-adwords_criteria_performance:
-    constraints:
-        unique:
-            - id
-        not_null:
-            - id
-
-adwords_url_performance:
-    constraints:
-        unique:
-            - id
-        not_null:
-            - id
-
-adwords_accounts:
-    constraints:
-        unique:
-            - account_id
-        not_null:
-            - account_id
-            
-adwords_ad_groups:
-    constraints:
-        unique:
-            - ad_group_id
-        not_null:
-            - ad_group_id
-            
-adwords_ads:
-    constraints:
-        unique:
-            - ad_id
-        not_null:
-            - ad_id
-            
-adwords_campaigns:
-    constraints:
-        unique:
-            - campaign_id
-        not_null:
-            - campaign_id
+models:
+  - name: adwords_click_performance
+    columns:
+        - name: gclid
+          tests:
+              - unique
+              - not_null
+              
+  - name: adwords_criteria_performance
+    columns:
+        - name: id
+          tests:
+              - unique
+              - not_null
+              
+  - name: adwords_url_performance
+    columns:
+        - name: id
+          tests:
+              - unique
+              - not_null
+              
+  - name: adwords_accounts
+    columns:
+        - name: account_id
+          tests:
+              - unique
+              - not_null
+              
+  - name: adwords_ad_groups
+    columns:
+        - name: ad_group_id
+          tests:
+              - unique
+              - not_null
+              
+  - name: adwords_ads
+    columns:
+        - name: ad_id
+          tests:
+              - unique
+              - not_null
+              
+  - name: adwords_campaigns
+    columns:
+        - name: campaign_id
+          tests:
+              - unique
+              - not_null

--- a/packages.yml
+++ b/packages.yml
@@ -1,0 +1,3 @@
+packages:
+ - package: fishtown-analytics/dbt-utils
+   version: 0.1.18

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
  - package: fishtown-analytics/dbt-utils
-   version: 0.1.18
+   version: '>=0.1.4'

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
- - package: fishtown-analytics/dbt-utils
-   version: '>=0.1.18'
+ - package: fishtown-analytics/dbt_utils
+   version: '>=0.1.20'

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
  - package: fishtown-analytics/dbt-utils
-   version: '>=0.1.4'
+   version: '>=0.1.18'


### PR DESCRIPTION
* updated `adwords_ad_performance_adapter` to point to `adwords_url_performance` model
-- this will enable us to get the `url_host` and `url_path` associated with an adwords ad campaign
-- added missing fields