### PR TITLE
resolve issue with criteria_id

### DIFF
--- a/macros/fivetran/fivetran_adwords_criteria_performance.sql
+++ b/macros/fivetran/fivetran_adwords_criteria_performance.sql
@@ -19,13 +19,13 @@ aggregated as (
         
         {{ dbt_utils.surrogate_key (
             'customer_id',
-            'criteria',
+            'id',
             'ad_group_id',
             'date'
         ) }}::varchar as id,
         
         date::date as date_day,
-        criteria as criteria_id,
+        id as criteria_id,
         ad_group_name,
         ad_group_id,
         ad_group_status as ad_group_state,


### PR DESCRIPTION
### Criteria Update

* the fivetran model for `criteria_performance` was incorrectly using the `criteria` field for `criteria_id` when it was actually a varchar
* this update allows us to use this downstream to build models needed for click performance with gclids