### PR TITLE
bump upper limit for dbt_utils to 0.7.0

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
  - package: fishtown-analytics/dbt_utils
-   version: [">=0.1.20"]
+   version: [">=0.1.20","<0.7.0"]

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
  - package: fishtown-analytics/dbt_utils
-   version: [">=0.1.20","<0.5.0"]
+   version: [">=0.1.20"]


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

This PR bumps the upper limit for `dbt_utils` in `packages.yml` to `0.7.0`. 

## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)