### PR TITLE
Bump dbt_utils min required version to 0.7.0

### DIFF
--- a/macros/fivetran/fivetran_adwords_criteria_performance.sql
+++ b/macros/fivetran/fivetran_adwords_criteria_performance.sql
@@ -18,10 +18,12 @@ aggregated as (
     select
         
         {{ dbt_utils.surrogate_key (
-            'customer_id',
-            'id',
-            'ad_group_id',
-            'date'
+            [
+              'customer_id',
+              'id',
+              'ad_group_id',
+              'date'
+            ]
         ) }}::varchar as id,
         
         date::date as date_day,

--- a/macros/fivetran/fivetran_adwords_url_performance.sql
+++ b/macros/fivetran/fivetran_adwords_url_performance.sql
@@ -18,12 +18,13 @@ aggregated as (
     select
 
         {{ dbt_utils.surrogate_key (
-            'customer_id',
-            'final_urls',
-            'date',
-            'campaign_id',
-            'ad_group_id'
-            
+            [
+              'customer_id',
+              'final_urls',
+              'date',
+              'campaign_id',
+              'ad_group_id'
+            ]
         ) }}::varchar as id,
 
         date::date as date_day,

--- a/macros/stitch/stitch_adwords_criteria_performance.sql
+++ b/macros/stitch/stitch_adwords_criteria_performance.sql
@@ -18,10 +18,12 @@ aggregated as (
     select
         
         {{ dbt_utils.surrogate_key (
-            'customerid',
-            'keywordid',
-            'adgroupid',
-            'day'
+            [
+              'customerid',
+              'keywordid',
+              'adgroupid',
+              'day'
+            ]
         ) }}::varchar as id,
         
         day::date as date_day,

--- a/macros/stitch/stitch_adwords_url_performance.sql
+++ b/macros/stitch/stitch_adwords_url_performance.sql
@@ -18,12 +18,13 @@ aggregated as (
     select
 
         {{ dbt_utils.surrogate_key (
-            'customerid',
-            'finalurl',
-            'day',
-            'campaignid',
-            'adgroupid'
-            
+            [
+              'customerid',
+              'finalurl',
+              'day',
+              'campaignid',
+              'adgroupid'
+            ]
         ) }}::varchar as id,
 
         day::date as date_day,

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: [">=0.7.0", "<0.8.0"]
+    version: [">=0.7.0", "<0.9.0"]

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
- - package: fishtown-analytics/dbt_utils
-   version: [">=0.1.20","<0.7.0"]
+  - package: dbt-labs/dbt_utils
+    version: [">=0.7.0", "<0.8.0"]


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

Latest versions of many other packages require `dbt-labs/dbt_utils >= 0.7.0` (e.g., `dbt-labs/facebook_ads`, `dbt-labs/snowplow`, `dbt-labs/dbt_external_tables`). This PR bumps the minimum required `dbt_utils` version to 0.7.0 and updates macro invocations accordingly.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)