### PR TITLE
Create CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @dbt-labs/dbt-package-owners


### PR DESCRIPTION
This PR creates a CODEOWNERS file with a global codeowner to act as a fallback owner.

If this repository is no longer in use and can be archived or deleted please let us know.

Please reach out to Security Engineering if you have any questions.